### PR TITLE
🔧 Fix: Improve NFT Metadata Error Handling 🛠️

### DIFF
--- a/src/components/MyNFTs.js
+++ b/src/components/MyNFTs.js
@@ -81,29 +81,35 @@ const MyNFTs = () => {
             const formattedNFTs = await Promise.all(
                 tokenURIs.map(async (uri, index) => {
                     try {
-                        const pinataURI = uri.replace(
-                            "ipfs://",
-                            "https://gateway.pinata.cloud/ipfs/"
-                        );
+                        const pinataURI = uri.replace("ipfs://", "https://gateway.pinata.cloud/ipfs/");
                         const response = await fetch(pinataURI);
+
+                        if (!response.ok) throw new Error(`Failed to fetch metadata: ${response.statusText}`);
+
                         const metadata = await response.json();
 
                         return {
-                            id: tokenIds[index].toString(), // Token ID
-                            name: metadata.name,
-                            description: metadata.description,
-                            image: metadata.image.replace(
-                                "ipfs://",
-                                "https://gateway.pinata.cloud/ipfs/"
-                            ),
-                            attributes: metadata.attributes || [], // Attributes
+                            id: tokenIds[index].toString(),
+                            name: metadata.name || `NFT #${tokenIds[index]}`,
+                            description: metadata.description || "No description available.",
+                            image: metadata.image
+                                ? metadata.image.replace("ipfs://", "https://gateway.pinata.cloud/ipfs/")
+                                : "https://via.placeholder.com/300", // Fallback image
+                            attributes: metadata.attributes || [],
                         };
                     } catch (err) {
-                        console.error("Failed to parse NFT metadata:", err);
-                        return null;
+                        console.error(`Error fetching metadata for token ${tokenIds[index]}:`, err);
+                        return {
+                            id: tokenIds[index].toString(),
+                            name: `NFT #${tokenIds[index]}`,
+                            description: "Metadata not available.",
+                            image: "https://via.placeholder.com/300",
+                            attributes: [],
+                        };
                     }
                 })
             );
+
 
             // Filter out invalid NFTs
             setNFTs(formattedNFTs.filter((nft) => nft !== null));


### PR DESCRIPTION
## ✨ Summary
This PR enhances the error handling when fetching NFT metadata to ensure a smoother user experience. Previously, if the metadata fetch failed or contained missing fields, the affected NFT would be excluded from the display. Now, NFTs with incomplete or unavailable metadata will still be shown with default values. 🚀

## 🔄 Changes
- ✅ Added robust error handling to prevent missing NFTs due to metadata fetch failures.
- 🖼️ Ensured NFTs have fallback values for `name`, `description`, and `image` if metadata is incomplete.
- 🛑 Used a placeholder image when the metadata image is missing to avoid broken UI.
- 📝 Improved logging to make debugging easier and provide better insights.

## 🛠️ How it Works
- If fetching metadata fails, the NFT is still displayed with a default name, description, and placeholder image.
- Errors are logged with the token ID 🔍 to help with debugging.
- This prevents cases where NFTs disappear from the UI due to metadata issues.

## ✅ Testing
- 🔍 Tested with valid NFT metadata: NFTs display correctly.
- ⚠️ Tested with invalid/missing metadata: NFTs still display with placeholders.
- 📌 Verified that errors are logged properly when metadata fetch fails.

## 🔗 Related Issue
Fixes #2 ✅  

## 📌 Notes
This PR ensures that users can **always** see their NFTs even if metadata retrieval fails, improving reliability and user experience. 🚀🎨  

---

**Looking forward to your feedback! 🚀🔥**
