### PR TITLE
🖼️ Fix Image Load Errors in NFTCard Component  

### DIFF
--- a/src/components/MyNFTs.js
+++ b/src/components/MyNFTs.js
@@ -16,6 +16,11 @@ const NFTCard = ({ nft }) => {
           className="w-full h-48 object-cover blur-sm transition-all duration-500 ease-in-out"
           loading="lazy"
           onLoad={(e) => e.target.classList.remove("blur-sm")}
+          onError={(e) => {
+            e.target.classList.remove("blur-sm");
+            e.target.src =
+              "https://via.placeholder.com/300?text=Image+Not+Found";
+          }}
         />
         <div className="absolute inset-0 bg-black bg-opacity-20 opacity-0 hover:opacity-100 transition-opacity duration-300"></div>
       </div>


### PR DESCRIPTION

## 📋 Description  

This PR fixes an issue in the `NFTCard` component where images with broken links would remain blurry indefinitely, causing a less-than-optimal user experience (the foggy NFTs problem! 👾).  

Now, when an image fails to load:  
- A fallback placeholder image will be displayed (no more mysterious foggy artifacts! 🌫️).  
- The blur effect will be removed even for failed images, ensuring everything looks clean and polished. ✨  

## 💡 Changes Made  
- Added an `onError` handler to the `img` tag in the `NFTCard` component.  
- Updated the `src` attribute to default to the placeholder for failed images.  
- Removed the `blur-sm` class when an image load error occurs.  

## 🔍 Code Snippet  

Here's the updated image rendering logic for better clarity:  

```jsx  
<img  
  src={nft.image || "https://via.placeholder.com/300"}  
  alt={nft.name || "NFT"}  
  className="w-full h-48 object-cover blur-sm transition-all duration-500 ease-in-out"  
  loading="lazy"  
  onLoad={(e) => e.target.classList.remove("blur-sm")}  
  onError={(e) => {  
    e.target.classList.remove("blur-sm");  
    e.target.src = "https://via.placeholder.com/300?text=Image+Not+Found";  
  }}  
/>
```

Fixed #10 