### PR TITLE
🔧 Fix: Add fetchNFTs to useEffect dependency array

### DIFF
--- a/src/components/MyNFTs.js
+++ b/src/components/MyNFTs.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useCallback } from "react";
 import { ethers } from "ethers";
 import { CONTRACT_ADDRESS, ABI } from "../contracts/contractConfig";
 import { useWalletContext } from "../contexts/WalletContext";
@@ -68,7 +68,7 @@ const MyNFTs = () => {
   const [error, setError] = useState(null); // Error state
 
   // Fetch NFTs from the contract
-  const fetchNFTs = async () => {
+  const fetchNFTs = useCallback(async () => {
     setLoading(true);
     setError(null);
 
@@ -124,12 +124,12 @@ const MyNFTs = () => {
     } finally {
       setLoading(false);
     }
-  };
+  }, [nfts]);
 
   useEffect(() => {
     if (!walletAddress) return; // Prevent unnecessary requests if wallet address is empty
     fetchNFTs();
-  }, [walletAddress]);
+  }, [walletAddress, fetchNFTs]);
 
   return (
     <div className="min-h-screen bg-blue-600 text-white p-8">


### PR DESCRIPTION



## 🌟 Overview
This PR addresses the missing dependency in the `useEffect` hook within the `MyNFTs` component. By properly memoizing the `fetchNFTs` function with `useCallback` and adding it to the dependency array, we eliminate potential stale closures and comply with React's exhaustive-deps rule.

## 🔗 Related Issues
Closes #12 (Missing fetchNFTs in useEffect dependency array causes potential stale closures)

## 🛠️ Changes
- Imported `useCallback` from React
- Wrapped the `fetchNFTs` function with `useCallback`
- Added `nfts` as a dependency to `useCallback` since it's used in the comparison
- Added `fetchNFTs` to the `useEffect` dependency array

## 🧪 Before / After

**Before:**
```javascript
const fetchNFTs = async () => {
  // Function implementation...
};

useEffect(() => {
  if (!walletAddress) return;
  fetchNFTs();
}, [walletAddress]);
```

**After:**
```javascript
const fetchNFTs = useCallback(async () => {
  // Function implementation...
}, [nfts]);

useEffect(() => {
  if (!walletAddress) return;
  fetchNFTs();
}, [walletAddress, fetchNFTs]);
```

## 🔍 Testing Done
- Verified that NFTs still load correctly
- Confirmed that the component updates appropriately when wallet address changes
- Checked that no React hook warnings appear in the console

## ✅ Checklist
- [x] Code follows project's style guidelines
- [x] Changes generate no new warnings
- [x] Tests pass locally
- [x] Documentation has been updated (if applicable)
- [x] Verified in development environment



---

This small change helps maintain the integrity of our React component lifecycle and prevents potential hard-to-debug issues that could arise in the future. 🚀
